### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/expression-vectorize.R
+++ b/R/expression-vectorize.R
@@ -14,7 +14,8 @@ expr_type <- function(x) {
 }
 
 switch_expr <- function(x, ...) {
-  switch(expr_type(x),
+  switch(
+    expr_type(x),
     ...,
     stop("Don't know how to handle type ", typeof(x), call. = FALSE)
   )
@@ -51,7 +52,11 @@ iteration_removal <- function(x, iteration_var) {
       }
 
       # Use base R variant because map2() catches all errors
-      args <- lapply(as.list(x)[-1], iteration_removal, iteration_var = iteration_var)
+      args <- lapply(
+        as.list(x)[-1],
+        iteration_removal,
+        iteration_var = iteration_var
+      )
       rlang::call2(x[[1]], !!!args)
     },
     pairlist = {

--- a/R/internal.R
+++ b/R/internal.R
@@ -17,7 +17,9 @@ add_new_variables <- function(values, object, expr, silent) {
   variables <- setdiff(variables, union(parameters, names_values))
 
   if (!length(variables)) {
-    err("`expr` must include at least one variable that is not in object or values")
+    err(
+      "`expr` must include at least one variable that is not in object or values"
+    )
   }
 
   values[variables] <- NA
@@ -49,7 +51,9 @@ drop_absent_values <- function(values, expr, silent) {
   drop <- name_values[!name_values %in% variables]
   if (length(drop)) {
     if (all(name_values %in% drop)) {
-      if (!silent) wrn("none of the variables in values are in expr")
+      if (!silent) {
+        wrn("none of the variables in values are in expr")
+      }
       return(list())
     }
     if (!silent) {
@@ -68,9 +72,14 @@ drop_absent_parameters <- function(object, expr, silent) {
   parameters <- pars(object)
   drop <- parameters[!parameters %in% variables]
   if (length(drop)) {
-    if (all(parameters %in% drop)) err("none of the parameters in object are in expr")
+    if (all(parameters %in% drop)) {
+      err("none of the parameters in object are in expr")
+    }
     if (!silent) {
-      wrn("the following parameters were not in expr and so were dropped from object: ", cc(drop))
+      wrn(
+        "the following parameters were not in expr and so were dropped from object: ",
+        cc(drop)
+      )
     }
     object <- subset(object, pars = setdiff(parameters, drop))
   }
@@ -85,7 +94,9 @@ subset_mcmcarray_chains <- function(x, chains) {
 subset_mcmcarray_iterations <- function(x, iterations) {
   x <- abind::asub(x, iterations, 2L, drop = FALSE)
   dim <- dim(x)[-c(1, 2)]
-  if (length(dim) == 1) dim <- NULL
+  if (length(dim) == 1) {
+    dim <- NULL
+  }
   dim(x) <- dim
   x
 }
@@ -123,7 +134,8 @@ monitor_variables <- function(monitor, values) {
   match <- variables[grepl(monitor, variables)]
   if (!length(match)) {
     err(
-      "`monitor` '", monitor,
+      "`monitor` '",
+      monitor,
       "' must match at least one of the following variables in expr: ",
       cc(variables, " or ")
     )
@@ -143,9 +155,13 @@ split_apply_combine_sample <- function(i, object, expr, values, monitor) {
 split_apply_combine_chain <- function(i, object, expr, values, monitor) {
   object <- subset_mcmcr_chains(object, chains = i)
 
-  object <- lapply(1:niters(object),
-    FUN = split_apply_combine_sample, object = object,
-    expr = expr, values = values, monitor = monitor
+  object <- lapply(
+    1:niters(object),
+    FUN = split_apply_combine_sample,
+    object = object,
+    expr = expr,
+    values = values,
+    monitor = monitor
   )
   object <- bind_iterations_mcmcrs(object)
   object
@@ -153,16 +169,27 @@ split_apply_combine_chain <- function(i, object, expr, values, monitor) {
 
 split_apply_combine <- function(object, expr, values, monitor, parallel) {
   if (parallel) {
-    rlang::check_installed("plyr", reason = "to run mcmc_derive on chains in parallel.")
-    object <- plyr::llply(1:nchains(object), split_apply_combine_chain,
+    rlang::check_installed(
+      "plyr",
+      reason = "to run mcmc_derive on chains in parallel."
+    )
+    object <- plyr::llply(
+      1:nchains(object),
+      split_apply_combine_chain,
       object = object,
-      .parallel = TRUE, expr = expr,
-      values = values, monitor = monitor
+      .parallel = TRUE,
+      expr = expr,
+      values = values,
+      monitor = monitor
     )
   } else {
-    object <- lapply(1:nchains(object), split_apply_combine_chain,
-      object = object, expr = expr,
-      values = values, monitor = monitor
+    object <- lapply(
+      1:nchains(object),
+      split_apply_combine_chain,
+      object = object,
+      expr = expr,
+      values = values,
+      monitor = monitor
     )
   }
 

--- a/R/mcmc-derive.R
+++ b/R/mcmc-derive.R
@@ -36,63 +36,114 @@ mcmc_derive <- function(object, ...) {
 
 #' @describeIn mcmc_derive Get derived parameters for an [nlist::nlist-object()]
 #' @export
-mcmc_derive.nlist <- function(object, expr, values = list(), monitor = ".*",
-                              primary = FALSE, silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.nlist <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   chk_unused(...)
   object <- as.mcmcr(object)
-  object <- mcmc_derive(object,
-    expr = {{ expr }}, values = values,
-    monitor = monitor, primary = primary, silent = silent
+  object <- mcmc_derive(
+    object,
+    expr = {{ expr }},
+    values = values,
+    monitor = monitor,
+    primary = primary,
+    silent = silent
   )
   nlist::as_nlist(object)
 }
 
 #' @describeIn mcmc_derive Get derived parameters for an [nlist::nlists-object()]
 #' @export
-mcmc_derive.nlists <- function(object, expr, values = list(), monitor = ".*",
-                               primary = FALSE, silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.nlists <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   chk_unused(...)
   object <- as.mcmcr(object)
-  object <- mcmc_derive(object,
-    expr = {{ expr }}, values = values,
-    monitor = monitor, primary = primary, silent = silent
+  object <- mcmc_derive(
+    object,
+    expr = {{ expr }},
+    values = values,
+    monitor = monitor,
+    primary = primary,
+    silent = silent
   )
   nlist::as_nlists(object)
 }
 
 #' @describeIn mcmc_derive Get derived parameters for an [coda::mcmc()] object
 #' @export
-mcmc_derive.mcmc <- function(object, expr, values = list(), monitor = ".*",
-                             primary = FALSE, silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.mcmc <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   chk_unused(...)
   object <- as.mcmcr(object)
-  object <- mcmc_derive(object,
-    expr = {{ expr }}, values = values,
-    monitor = monitor, primary = primary, silent = silent
+  object <- mcmc_derive(
+    object,
+    expr = {{ expr }},
+    values = values,
+    monitor = monitor,
+    primary = primary,
+    silent = silent
   )
   coda::as.mcmc(object)
 }
 
 #' @describeIn mcmc_derive Get derived parameters for an [coda::mcmc.list()] object
 #' @export
-mcmc_derive.mcmc.list <- function(object, expr, values = list(), monitor = ".*",
-                                  primary = FALSE, parallel = FALSE,
-                                  silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.mcmc.list <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  parallel = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   chk_unused(...)
   object <- as.mcmcr(object)
-  object <- mcmc_derive(object,
-    expr = {{ expr }}, values = values,
-    monitor = monitor, primary = primary,
-    parallel = parallel, silent = silent
+  object <- mcmc_derive(
+    object,
+    expr = {{ expr }},
+    values = values,
+    monitor = monitor,
+    primary = primary,
+    parallel = parallel,
+    silent = silent
   )
   coda::as.mcmc.list(object)
 }
 
 #' @describeIn mcmc_derive Get derived parameters for an [mcmcr::mcmcr-object()]
 #' @export
-mcmc_derive.mcmcr <- function(object, expr, values = list(), monitor = ".*",
-                              primary = FALSE, parallel = FALSE,
-                              silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.mcmcr <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  parallel = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   expr <- enexpr_expr({{ expr }})
 
   chk_list(values)
@@ -126,12 +177,25 @@ mcmc_derive.mcmcr <- function(object, expr, values = list(), monitor = ".*",
 
 #' @describeIn mcmc_derive Get derived parameters for an [mcmcr::mcmcrs-object()]
 #' @export
-mcmc_derive.mcmcrs <- function(object, expr, values = list(), monitor = ".*",
-                               primary = FALSE, parallel = FALSE, silent = getOption("mcmcderive.silent", FALSE), ...) {
+mcmc_derive.mcmcrs <- function(
+  object,
+  expr,
+  values = list(),
+  monitor = ".*",
+  primary = FALSE,
+  parallel = FALSE,
+  silent = getOption("mcmcderive.silent", FALSE),
+  ...
+) {
   chk_unused(...)
-  object <- lapply(object, mcmc_derive,
-    expr = {{ expr }}, values = values,
-    monitor = monitor, primary = primary, parallel = parallel,
+  object <- lapply(
+    object,
+    mcmc_derive,
+    expr = {{ expr }},
+    values = values,
+    monitor = monitor,
+    primary = primary,
+    parallel = parallel,
     silent = silent
   )
   as.mcmcrs(object)

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-expression-vectorize.R
+++ b/tests/testthat/test-expression-vectorize.R
@@ -23,7 +23,9 @@ test_that("iteration var replaced with squared term", {
   expect_snapshot(
     expression_vectorize(rlang::expr(
       for (i in seq_along(LogLength)) {
-        eWeightLength[i] <- bWeightLength + bDayte * Dayte[i] + bDayte2 * Dayte[i]^2
+        eWeightLength[i] <- bWeightLength +
+          bDayte * Dayte[i] +
+          bDayte2 * Dayte[i]^2
       }
     ))
   )
@@ -45,7 +47,10 @@ test_that("iteration var replaced and cbind added to arrays", {
   expect_snapshot(
     expression_vectorize(rlang::expr(
       for (i in 1:nObs) {
-        log(eCount[i]) <- b0 + bYear * Year[i] + bAnnual[Annual[i]] + bSiteAnnual[Site[i], Annual[i]]
+        log(eCount[i]) <- b0 +
+          bYear * Year[i] +
+          bAnnual[Annual[i]] +
+          bSiteAnnual[Site[i], Annual[i]]
         fit[i] <- eCount[i]
         residual[i] <- res_gamma_pois(Count[i], fit[i], sSiteAnnualQuadrat)
       }
@@ -57,9 +62,23 @@ test_that("expr with mutli lines", {
   expect_snapshot(
     expression_vectorize(rlang::expr(
       for (i in 1:nObs) {
-        log(eCount[i]) <- b0 + bYear * Year[i] + bKelpLine * KelpLine[i] + bSite[Site[i]] + bAnnual[Annual[i]] + bSiteAnnual[Site[i], Annual[i]]
-        log(eCountKelpline[i]) <- b0 + bKelpLine + bYear * Year[i] + bAnnual[Annual[i]] + bSite[Site[i]] + bSiteAnnual[Site[i], Annual[i]]
-        log(eCountBarren[i]) <- b0 + bYear * Year[i] + bAnnual[Annual[i]] + bSite[Site[i]] + bSiteAnnual[Site[i], Annual[i]]
+        log(eCount[i]) <- b0 +
+          bYear * Year[i] +
+          bKelpLine * KelpLine[i] +
+          bSite[Site[i]] +
+          bAnnual[Annual[i]] +
+          bSiteAnnual[Site[i], Annual[i]]
+        log(eCountKelpline[i]) <- b0 +
+          bKelpLine +
+          bYear * Year[i] +
+          bAnnual[Annual[i]] +
+          bSite[Site[i]] +
+          bSiteAnnual[Site[i], Annual[i]]
+        log(eCountBarren[i]) <- b0 +
+          bYear * Year[i] +
+          bAnnual[Annual[i]] +
+          bSite[Site[i]] +
+          bSiteAnnual[Site[i], Annual[i]]
       }
     ))
   )
@@ -85,7 +104,11 @@ test_that("sum() inside the expression leaves the for loop unchanged", {
   expect_snapshot(
     expression_vectorize(rlang::expr(
       for (i in seq_along(Year)) {
-        eGrowth[i] <- max(0, (bLinf - LengthAtRelease[i]) * (1 - exp(-sum(eK[Year[i]:(Year[i] + dYears[i] - 1)]))))
+        eGrowth[i] <- max(
+          0,
+          (bLinf - LengthAtRelease[i]) *
+            (1 - exp(-sum(eK[Year[i]:(Year[i] + dYears[i] - 1)])))
+        )
       }
     ))
   )
@@ -117,7 +140,12 @@ test_that("more than two dimensions", {
   expect_snapshot(
     expression_vectorize(rlang::expr(
       for (i in 1:nObs) {
-        log(eCount[i]) <- b0 + bKelpLine * KelpLine[i] + bYear * Year[i] + bSite[Site[i]] + bSiteAnnual[Site[i], Annual[i]] + bAnnual[Annual[i]]
+        log(eCount[i]) <- b0 +
+          bKelpLine * KelpLine[i] +
+          bYear * Year[i] +
+          bSite[Site[i]] +
+          bSiteAnnual[Site[i], Annual[i]] +
+          bAnnual[Annual[i]]
         dpois(eCount[i] * bSiteAnnualQuadrat[Site[i], Annual[i], Quadrat[i]])
       }
     ))

--- a/tests/testthat/test-mcmc-derive.R
+++ b/tests/testthat/test-mcmc-derive.R
@@ -30,9 +30,14 @@ test_that("mcmc_derive.nlist with expression passed in argument", {
   nlist <- nlist::nlist(x = 1:2, y = matrix(1:4, 2))
 
   expect_equal(
-    mcmc_derive(nlist, !!rlang::expr({
-      gamma <- x + 2; z <- y[1, 2]
-    }), silent = TRUE),
+    mcmc_derive(
+      nlist,
+      !!rlang::expr({
+        gamma <- x + 2
+        z <- y[1, 2]
+      }),
+      silent = TRUE
+    ),
     nlist::nlist(gamma = c(3, 4), z = 3L)
   )
 })
@@ -41,9 +46,11 @@ test_that("mcmc_derive.nlist with expression directly in it", {
   nlist <- nlist::nlist(x = 1:2, y = matrix(1:4, 2))
 
   expect_equal(
-    mcmc_derive(nlist,
+    mcmc_derive(
+      nlist,
       {
-        gamma <- x + 2; z <- y[1, 2]
+        gamma <- x + 2
+        z <- y[1, 2]
       },
       silent = TRUE
     ),
@@ -108,20 +115,63 @@ test_that("mcmc_derive.mcmc", {
 
   expect_equal(
     mcmc_derive(mcmc, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(c(
-      14.34626, 5.90506, 16.34626, 7.90506, 14.34626, 5.90506,
-      21.51939, 8.85759, 28.69252, 11.81012, 35.86565, 14.76265, 43.03878,
-      17.71518, 50.21191, 20.66771, 57.38504, 23.62024, 64.55817, 26.57277,
-      71.7313, 29.5253, 5.60693, 4.4559, 7.60693, 6.4559, 6.60693,
-      5.4559, 8.60693, 7.4559
-    ), .Dim = c(2L, 15L), .Dimnames = list(
-      NULL, c(
-        "alpha2[1]", "alpha2[2]", "alpha3[1]", "alpha3[2]",
-        "alpha3[3]", "alpha3[4]", "alpha3[5]", "alpha3[6]", "alpha3[7]",
-        "alpha3[8]", "alpha3[9]", "gamma[1,1]", "gamma[2,1]", "gamma[1,2]",
-        "gamma[2,2]"
-      )
-    ), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      c(
+        14.34626,
+        5.90506,
+        16.34626,
+        7.90506,
+        14.34626,
+        5.90506,
+        21.51939,
+        8.85759,
+        28.69252,
+        11.81012,
+        35.86565,
+        14.76265,
+        43.03878,
+        17.71518,
+        50.21191,
+        20.66771,
+        57.38504,
+        23.62024,
+        64.55817,
+        26.57277,
+        71.7313,
+        29.5253,
+        5.60693,
+        4.4559,
+        7.60693,
+        6.4559,
+        6.60693,
+        5.4559,
+        8.60693,
+        7.4559
+      ),
+      .Dim = c(2L, 15L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "alpha2[1]",
+          "alpha2[2]",
+          "alpha3[1]",
+          "alpha3[2]",
+          "alpha3[3]",
+          "alpha3[4]",
+          "alpha3[5]",
+          "alpha3[6]",
+          "alpha3[7]",
+          "alpha3[8]",
+          "alpha3[9]",
+          "gamma[1,1]",
+          "gamma[2,1]",
+          "gamma[1,2]",
+          "gamma[2,2]"
+        )
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 })
 
@@ -141,20 +191,63 @@ test_that("mcmc_derive.mcmc with expression", {
 
   expect_equal(
     mcmc_derive(mcmc, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(c(
-      14.34626, 5.90506, 16.34626, 7.90506, 14.34626, 5.90506,
-      21.51939, 8.85759, 28.69252, 11.81012, 35.86565, 14.76265, 43.03878,
-      17.71518, 50.21191, 20.66771, 57.38504, 23.62024, 64.55817, 26.57277,
-      71.7313, 29.5253, 5.60693, 4.4559, 7.60693, 6.4559, 6.60693,
-      5.4559, 8.60693, 7.4559
-    ), .Dim = c(2L, 15L), .Dimnames = list(
-      NULL, c(
-        "alpha2[1]", "alpha2[2]", "alpha3[1]", "alpha3[2]",
-        "alpha3[3]", "alpha3[4]", "alpha3[5]", "alpha3[6]", "alpha3[7]",
-        "alpha3[8]", "alpha3[9]", "gamma[1,1]", "gamma[2,1]", "gamma[1,2]",
-        "gamma[2,2]"
-      )
-    ), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      c(
+        14.34626,
+        5.90506,
+        16.34626,
+        7.90506,
+        14.34626,
+        5.90506,
+        21.51939,
+        8.85759,
+        28.69252,
+        11.81012,
+        35.86565,
+        14.76265,
+        43.03878,
+        17.71518,
+        50.21191,
+        20.66771,
+        57.38504,
+        23.62024,
+        64.55817,
+        26.57277,
+        71.7313,
+        29.5253,
+        5.60693,
+        4.4559,
+        7.60693,
+        6.4559,
+        6.60693,
+        5.4559,
+        8.60693,
+        7.4559
+      ),
+      .Dim = c(2L, 15L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "alpha2[1]",
+          "alpha2[2]",
+          "alpha3[1]",
+          "alpha3[2]",
+          "alpha3[3]",
+          "alpha3[4]",
+          "alpha3[5]",
+          "alpha3[6]",
+          "alpha3[7]",
+          "alpha3[8]",
+          "alpha3[9]",
+          "gamma[1,1]",
+          "gamma[2,1]",
+          "gamma[1,2]",
+          "gamma[2,2]"
+        )
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 })
 
@@ -173,21 +266,73 @@ test_that("mcmc_derive.mcmc.list", {
   values <- list(x = 2:10)
 
   expect_equal(
-    mcmc_derive(mcmc.list, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(list(structure(c(
-      14.34626, 5.90506, 16.34626, 7.90506,
-      14.34626, 5.90506, 21.51939, 8.85759, 28.69252, 11.81012, 35.86565,
-      14.76265, 43.03878, 17.71518, 50.21191, 20.66771, 57.38504, 23.62024,
-      64.55817, 26.57277, 71.7313, 29.5253, 5.60693, 4.4559, 7.60693,
-      6.4559, 6.60693, 5.4559, 8.60693, 7.4559
-    ), .Dim = c(2L, 15L), .Dimnames = list(
-      NULL, c(
-        "alpha2[1]", "alpha2[2]", "alpha3[1]", "alpha3[2]",
-        "alpha3[3]", "alpha3[4]", "alpha3[5]", "alpha3[6]", "alpha3[7]",
-        "alpha3[8]", "alpha3[9]", "gamma[1,1]", "gamma[2,1]", "gamma[1,2]",
-        "gamma[2,2]"
-      )
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    mcmc_derive(
+      mcmc.list,
+      expr,
+      values = values,
+      monitor = "^g|^a",
+      silent = TRUE
+    ),
+    structure(
+      list(structure(
+        c(
+          14.34626,
+          5.90506,
+          16.34626,
+          7.90506,
+          14.34626,
+          5.90506,
+          21.51939,
+          8.85759,
+          28.69252,
+          11.81012,
+          35.86565,
+          14.76265,
+          43.03878,
+          17.71518,
+          50.21191,
+          20.66771,
+          57.38504,
+          23.62024,
+          64.55817,
+          26.57277,
+          71.7313,
+          29.5253,
+          5.60693,
+          4.4559,
+          7.60693,
+          6.4559,
+          6.60693,
+          5.4559,
+          8.60693,
+          7.4559
+        ),
+        .Dim = c(2L, 15L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "alpha2[1]",
+            "alpha2[2]",
+            "alpha3[1]",
+            "alpha3[2]",
+            "alpha3[3]",
+            "alpha3[4]",
+            "alpha3[5]",
+            "alpha3[6]",
+            "alpha3[7]",
+            "alpha3[8]",
+            "alpha3[9]",
+            "gamma[1,1]",
+            "gamma[2,1]",
+            "gamma[1,2]",
+            "gamma[2,2]"
+          )
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 })
 
@@ -206,21 +351,73 @@ test_that("mcmc_derive.mcmc.list with expression", {
   values <- list(x = 2:10)
 
   expect_equal(
-    mcmc_derive(mcmc.list, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(list(structure(c(
-      14.34626, 5.90506, 16.34626, 7.90506,
-      14.34626, 5.90506, 21.51939, 8.85759, 28.69252, 11.81012, 35.86565,
-      14.76265, 43.03878, 17.71518, 50.21191, 20.66771, 57.38504, 23.62024,
-      64.55817, 26.57277, 71.7313, 29.5253, 5.60693, 4.4559, 7.60693,
-      6.4559, 6.60693, 5.4559, 8.60693, 7.4559
-    ), .Dim = c(2L, 15L), .Dimnames = list(
-      NULL, c(
-        "alpha2[1]", "alpha2[2]", "alpha3[1]", "alpha3[2]",
-        "alpha3[3]", "alpha3[4]", "alpha3[5]", "alpha3[6]", "alpha3[7]",
-        "alpha3[8]", "alpha3[9]", "gamma[1,1]", "gamma[2,1]", "gamma[1,2]",
-        "gamma[2,2]"
-      )
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    mcmc_derive(
+      mcmc.list,
+      expr,
+      values = values,
+      monitor = "^g|^a",
+      silent = TRUE
+    ),
+    structure(
+      list(structure(
+        c(
+          14.34626,
+          5.90506,
+          16.34626,
+          7.90506,
+          14.34626,
+          5.90506,
+          21.51939,
+          8.85759,
+          28.69252,
+          11.81012,
+          35.86565,
+          14.76265,
+          43.03878,
+          17.71518,
+          50.21191,
+          20.66771,
+          57.38504,
+          23.62024,
+          64.55817,
+          26.57277,
+          71.7313,
+          29.5253,
+          5.60693,
+          4.4559,
+          7.60693,
+          6.4559,
+          6.60693,
+          5.4559,
+          8.60693,
+          7.4559
+        ),
+        .Dim = c(2L, 15L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "alpha2[1]",
+            "alpha2[2]",
+            "alpha3[1]",
+            "alpha3[2]",
+            "alpha3[3]",
+            "alpha3[4]",
+            "alpha3[5]",
+            "alpha3[6]",
+            "alpha3[7]",
+            "alpha3[8]",
+            "alpha3[9]",
+            "gamma[1,1]",
+            "gamma[2,1]",
+            "gamma[1,2]",
+            "gamma[2,2]"
+          )
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 })
 
@@ -240,27 +437,97 @@ test_that("mcmc_derive.mcmcr", {
 
   expect_equal(
     mcmc_derive(mcmcr, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(list(alpha2 = structure(c(
-      14.34626, 4.133, 5.90506,
-      5.10146, 16.34626, 6.133, 7.90506, 7.10146
-    ), .Dim = c(
-      2L, 2L,
-      2L
-    ), class = "mcmcarray"), alpha3 = structure(c(
-      14.34626, 4.133,
-      5.90506, 5.10146, 21.51939, 6.1995, 8.85759, 7.65219, 28.69252,
-      8.266, 11.81012, 10.20292, 35.86565, 10.3325, 14.76265, 12.75365,
-      43.03878, 12.399, 17.71518, 15.30438, 50.21191, 14.4655, 20.66771,
-      17.85511, 57.38504, 16.532, 23.62024, 20.40584, 64.55817, 18.5985,
-      26.57277, 22.95657, 71.7313, 20.665, 29.5253, 25.5073
-    ), .Dim = c(
-      2L,
-      2L, 9L
-    ), class = "mcmcarray"), gamma = structure(c(
-      5.60693, 3.01633,
-      4.4559, 3.084598, 7.60693, 5.01633, 6.4559, 5.084598, 6.60693,
-      4.01633, 5.4559, 4.084598, 8.60693, 6.01633, 7.4559, 6.084598
-    ), .Dim = c(2L, 2L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        alpha2 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            16.34626,
+            6.133,
+            7.90506,
+            7.10146
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        alpha3 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            21.51939,
+            6.1995,
+            8.85759,
+            7.65219,
+            28.69252,
+            8.266,
+            11.81012,
+            10.20292,
+            35.86565,
+            10.3325,
+            14.76265,
+            12.75365,
+            43.03878,
+            12.399,
+            17.71518,
+            15.30438,
+            50.21191,
+            14.4655,
+            20.66771,
+            17.85511,
+            57.38504,
+            16.532,
+            23.62024,
+            20.40584,
+            64.55817,
+            18.5985,
+            26.57277,
+            22.95657,
+            71.7313,
+            20.665,
+            29.5253,
+            25.5073
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            9L
+          ),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(
+            5.60693,
+            3.01633,
+            4.4559,
+            3.084598,
+            7.60693,
+            5.01633,
+            6.4559,
+            5.084598,
+            6.60693,
+            4.01633,
+            5.4559,
+            4.084598,
+            8.60693,
+            6.01633,
+            7.4559,
+            6.084598
+          ),
+          .Dim = c(2L, 2L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -280,27 +547,97 @@ test_that("mcmc_derive.mcmcr with expression", {
 
   expect_equal(
     mcmc_derive(mcmcr, expr, values = values, monitor = "^g|^a", silent = TRUE),
-    structure(list(alpha2 = structure(c(
-      14.34626, 4.133, 5.90506,
-      5.10146, 16.34626, 6.133, 7.90506, 7.10146
-    ), .Dim = c(
-      2L, 2L,
-      2L
-    ), class = "mcmcarray"), alpha3 = structure(c(
-      14.34626, 4.133,
-      5.90506, 5.10146, 21.51939, 6.1995, 8.85759, 7.65219, 28.69252,
-      8.266, 11.81012, 10.20292, 35.86565, 10.3325, 14.76265, 12.75365,
-      43.03878, 12.399, 17.71518, 15.30438, 50.21191, 14.4655, 20.66771,
-      17.85511, 57.38504, 16.532, 23.62024, 20.40584, 64.55817, 18.5985,
-      26.57277, 22.95657, 71.7313, 20.665, 29.5253, 25.5073
-    ), .Dim = c(
-      2L,
-      2L, 9L
-    ), class = "mcmcarray"), gamma = structure(c(
-      5.60693, 3.01633,
-      4.4559, 3.084598, 7.60693, 5.01633, 6.4559, 5.084598, 6.60693,
-      4.01633, 5.4559, 4.084598, 8.60693, 6.01633, 7.4559, 6.084598
-    ), .Dim = c(2L, 2L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        alpha2 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            16.34626,
+            6.133,
+            7.90506,
+            7.10146
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        alpha3 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            21.51939,
+            6.1995,
+            8.85759,
+            7.65219,
+            28.69252,
+            8.266,
+            11.81012,
+            10.20292,
+            35.86565,
+            10.3325,
+            14.76265,
+            12.75365,
+            43.03878,
+            12.399,
+            17.71518,
+            15.30438,
+            50.21191,
+            14.4655,
+            20.66771,
+            17.85511,
+            57.38504,
+            16.532,
+            23.62024,
+            20.40584,
+            64.55817,
+            18.5985,
+            26.57277,
+            22.95657,
+            71.7313,
+            20.665,
+            29.5253,
+            25.5073
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            9L
+          ),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(
+            5.60693,
+            3.01633,
+            4.4559,
+            3.084598,
+            7.60693,
+            5.01633,
+            6.4559,
+            5.084598,
+            6.60693,
+            4.01633,
+            5.4559,
+            4.084598,
+            8.60693,
+            6.01633,
+            7.4559,
+            6.084598
+          ),
+          .Dim = c(2L, 2L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -310,16 +647,41 @@ test_that("mcmc_derive.mcmcrs", {
 
   expect_equal(
     mcmc_derive(mcmcrs, "gamma <- alpha + beta", silent = TRUE),
-    structure(list(
-      mcmcr1 = structure(list(gamma = structure(c(
-        5.60693,
-        7.60693, 6.60693, 8.60693
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr"),
-      mcmcr2 = structure(list(gamma = structure(c(
-        5.60693, 7.60693,
-        6.60693, 8.60693
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
-    ), class = "mcmcrs")
+    structure(
+      list(
+        mcmcr1 = structure(
+          list(
+            gamma = structure(
+              c(
+                5.60693,
+                7.60693,
+                6.60693,
+                8.60693
+              ),
+              .Dim = c(1L, 1L, 2L, 2L),
+              class = "mcmcarray"
+            )
+          ),
+          class = "mcmcr"
+        ),
+        mcmcr2 = structure(
+          list(
+            gamma = structure(
+              c(
+                5.60693,
+                7.60693,
+                6.60693,
+                8.60693
+              ),
+              .Dim = c(1L, 1L, 2L, 2L),
+              class = "mcmcarray"
+            )
+          ),
+          class = "mcmcr"
+        )
+      ),
+      class = "mcmcrs"
+    )
   )
 })
 
@@ -333,16 +695,41 @@ test_that("mcmc_derive.mcmcrs with expression", {
 
   expect_equal(
     mcmc_derive(mcmcrs, expr, silent = TRUE),
-    structure(list(
-      mcmcr1 = structure(list(gamma = structure(c(
-        5.60693,
-        7.60693, 6.60693, 8.60693
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr"),
-      mcmcr2 = structure(list(gamma = structure(c(
-        5.60693, 7.60693,
-        6.60693, 8.60693
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
-    ), class = "mcmcrs")
+    structure(
+      list(
+        mcmcr1 = structure(
+          list(
+            gamma = structure(
+              c(
+                5.60693,
+                7.60693,
+                6.60693,
+                8.60693
+              ),
+              .Dim = c(1L, 1L, 2L, 2L),
+              class = "mcmcarray"
+            )
+          ),
+          class = "mcmcr"
+        ),
+        mcmcr2 = structure(
+          list(
+            gamma = structure(
+              c(
+                5.60693,
+                7.60693,
+                6.60693,
+                8.60693
+              ),
+              .Dim = c(1L, 1L, 2L, 2L),
+              class = "mcmcarray"
+            )
+          ),
+          class = "mcmcr"
+        )
+      ),
+      class = "mcmcrs"
+    )
   )
 })
 
@@ -352,15 +739,28 @@ test_that("mcmc_derive.mcmcr with all missing data.frame", {
   values <- data.frame(theta = c(2, 3))
 
   expect_equal(
-    mcmc_derive(mcmcr, "prediction <- alpha + beta + theta",
+    mcmc_derive(
+      mcmcr,
+      "prediction <- alpha + beta + theta",
       silent = TRUE,
       monitor = "^prediction$",
       values = values
     ),
-    structure(list(prediction = structure(c(
-      7.60693, 10.60693, 8.60693,
-      11.60693
-    ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        prediction = structure(
+          c(
+            7.60693,
+            10.60693,
+            8.60693,
+            11.60693
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -384,31 +784,105 @@ test_that("mcmc_derive in parallel", {
   doParallel::registerDoParallel(2)
 
   expect_equal(
-    mcmc_derive(mcmcr, expr,
-      values = values, monitor = "^g|^a",
-      parallel = TRUE, silent = TRUE
+    mcmc_derive(
+      mcmcr,
+      expr,
+      values = values,
+      monitor = "^g|^a",
+      parallel = TRUE,
+      silent = TRUE
     ),
-    structure(list(alpha2 = structure(c(
-      14.34626, 4.133, 5.90506,
-      5.10146, 16.34626, 6.133, 7.90506, 7.10146
-    ), .Dim = c(
-      2L, 2L,
-      2L
-    ), class = "mcmcarray"), alpha3 = structure(c(
-      14.34626, 4.133,
-      5.90506, 5.10146, 21.51939, 6.1995, 8.85759, 7.65219, 28.69252,
-      8.266, 11.81012, 10.20292, 35.86565, 10.3325, 14.76265, 12.75365,
-      43.03878, 12.399, 17.71518, 15.30438, 50.21191, 14.4655, 20.66771,
-      17.85511, 57.38504, 16.532, 23.62024, 20.40584, 64.55817, 18.5985,
-      26.57277, 22.95657, 71.7313, 20.665, 29.5253, 25.5073
-    ), .Dim = c(
-      2L,
-      2L, 9L
-    ), class = "mcmcarray"), gamma = structure(c(
-      5.60693, 3.01633,
-      4.4559, 3.084598, 7.60693, 5.01633, 6.4559, 5.084598, 6.60693,
-      4.01633, 5.4559, 4.084598, 8.60693, 6.01633, 7.4559, 6.084598
-    ), .Dim = c(2L, 2L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        alpha2 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            16.34626,
+            6.133,
+            7.90506,
+            7.10146
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        alpha3 = structure(
+          c(
+            14.34626,
+            4.133,
+            5.90506,
+            5.10146,
+            21.51939,
+            6.1995,
+            8.85759,
+            7.65219,
+            28.69252,
+            8.266,
+            11.81012,
+            10.20292,
+            35.86565,
+            10.3325,
+            14.76265,
+            12.75365,
+            43.03878,
+            12.399,
+            17.71518,
+            15.30438,
+            50.21191,
+            14.4655,
+            20.66771,
+            17.85511,
+            57.38504,
+            16.532,
+            23.62024,
+            20.40584,
+            64.55817,
+            18.5985,
+            26.57277,
+            22.95657,
+            71.7313,
+            20.665,
+            29.5253,
+            25.5073
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            9L
+          ),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(
+            5.60693,
+            3.01633,
+            4.4559,
+            3.084598,
+            7.60693,
+            5.01633,
+            6.4559,
+            5.084598,
+            6.60693,
+            4.01633,
+            5.4559,
+            4.084598,
+            8.60693,
+            6.01633,
+            7.4559,
+            6.084598
+          ),
+          .Dim = c(2L, 2L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -430,14 +904,38 @@ test_that("mcmc_derive matrix in values", {
 
   expect_equal(
     mcmc_derive(mcmcr, expr, values = values, monitor = "x"),
-    structure(list(x = structure(c(
-      -1.5662, 0.94983, 1.50337, 0.533868,
-      -0.5662, 1.94983, 2.50337, 1.533868, -0.5662, 1.94983, 2.50337,
-      1.533868, 0.4338, 2.94983, 3.50337, 2.533868
-    ), .Dim = c(
-      2L, 2L,
-      2L, 2L
-    ), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        x = structure(
+          c(
+            -1.5662,
+            0.94983,
+            1.50337,
+            0.533868,
+            -0.5662,
+            1.94983,
+            2.50337,
+            1.533868,
+            -0.5662,
+            1.94983,
+            2.50337,
+            1.533868,
+            0.4338,
+            2.94983,
+            3.50337,
+            2.533868
+          ),
+          .Dim = c(
+            2L,
+            2L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -450,7 +948,8 @@ test_that("mcmc_derive warnings and errors", {
   )
 
   expect_error(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       expr = "alpha <- beta",
       values = list(alpha = 1, beta = 2, sigma = 3)
     ),
@@ -458,7 +957,8 @@ test_that("mcmc_derive warnings and errors", {
   )
 
   expect_warning(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       expr = "alpha2 <- beta * sigma + alpha",
       values = list(alpha = 1)
     ),
@@ -466,7 +966,8 @@ test_that("mcmc_derive warnings and errors", {
   )
 
   expect_warning(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       expr = "alpha2 <- beta * sigma + alpha",
       values = list(alpha3 = 1)
     ),
@@ -474,7 +975,8 @@ test_that("mcmc_derive warnings and errors", {
   )
 
   expect_warning(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       expr = "alpha2 <- beta + beta3 * sigma + alpha",
       values = list(alpha3 = 1, beta3 = 2)
     ),
@@ -491,25 +993,34 @@ test_that("mcmc_derive warnings and errors", {
     "^None of the parameters in object are in expr[.]$"
   )
 
-
   expect_error(
     mcmc_derive(mcmcr, expr = "alpha <- beta * sigma"),
     "^`expr` must include at least one variable that is not in object or values[.]$"
   )
 
   expect_error(
-    mcmc_derive(mcmcr, expr = "alpha2 <- beta * sigma * alpha", monitor = "alpha3"),
+    mcmc_derive(
+      mcmcr,
+      expr = "alpha2 <- beta * sigma * alpha",
+      monitor = "alpha3"
+    ),
     "^`monitor` 'alpha3' must match at least one of the following variables in expr: 'alpha2'[.]$"
   )
 
   expect_identical(
-    mcmc_derive(mcmcr, expr = "alpha2 <- beta * sigma * alpha * alpha3", monitor = "2$"),
+    mcmc_derive(
+      mcmcr,
+      expr = "alpha2 <- beta * sigma * alpha * alpha3",
+      monitor = "2$"
+    ),
     mcmcr::fill_all(set_pars(subset(mcmcr, pars = "beta"), "alpha2"), NA_real_)
   )
 
   expect_error(
-    mcmc_derive(mcmcr,
-      expr = "gamma <- alpha", monitor = "something",
+    mcmc_derive(
+      mcmcr,
+      expr = "gamma <- alpha",
+      monitor = "something",
       silent = TRUE
     ),
     "^`monitor` 'something' must match at least one of the following variables in expr: 'gamma'[.]$"
@@ -522,68 +1033,148 @@ test_that("mcmc_derive with primary = TRUE", {
 
   expect_equal(
     mcmc_derive(mcmcr, "gamma <- alpha + beta", primary = FALSE, silent = TRUE),
-    structure(list(gamma = structure(c(
-      5.60693, 7.60693, 6.60693,
-      8.60693
-    ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(
+            5.60693,
+            7.60693,
+            6.60693,
+            8.60693
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   # doesn't include alpha as primary = FALSE
   expect_equal(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       "gamma <- alpha + beta
                            alpha <- alpha * 2",
-      primary = FALSE, silent = TRUE
+      primary = FALSE,
+      silent = TRUE
     ),
-    structure(list(gamma = structure(c(
-      5.60693, 7.60693, 6.60693,
-      8.60693
-    ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(
+            5.60693,
+            7.60693,
+            6.60693,
+            8.60693
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   expect_equal(
     mcmc_derive(mcmcr, "gamma <- alpha + beta", primary = TRUE, silent = TRUE),
-    structure(list(
-      alpha = structure(c(7.17313, 8.17313), .Dim = c(
-        1L,
-        1L, 2L
-      ), class = "mcmcarray"), beta = structure(c(
-        -1.5662, -0.5662,
-        -0.5662, 0.4338
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray"),
-      gamma = structure(c(5.60693, 7.60693, 6.60693, 8.60693), .Dim = c(
-        1L,
-        1L, 2L, 2L
-      ), class = "mcmcarray"), sigma = structure(11.2331, .Dim = c(
-        1L,
-        1L, 1L
-      ), class = "mcmcarray")
-    ), class = "mcmcr")
+    structure(
+      list(
+        alpha = structure(
+          c(7.17313, 8.17313),
+          .Dim = c(
+            1L,
+            1L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        beta = structure(
+          c(
+            -1.5662,
+            -0.5662,
+            -0.5662,
+            0.4338
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(5.60693, 7.60693, 6.60693, 8.60693),
+          .Dim = c(
+            1L,
+            1L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        sigma = structure(
+          11.2331,
+          .Dim = c(
+            1L,
+            1L,
+            1L
+          ),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   # goes with original alpha
   expect_equal(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       "gamma <- alpha + beta
                            alpha <- alpha * 2",
-      primary = TRUE, silent = TRUE
+      primary = TRUE,
+      silent = TRUE
     ),
-    structure(list(
-      alpha = structure(c(7.17313, 8.17313), .Dim = c(
-        1L,
-        1L, 2L
-      ), class = "mcmcarray"), beta = structure(c(
-        -1.5662, -0.5662,
-        -0.5662, 0.4338
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray"),
-      gamma = structure(c(5.60693, 7.60693, 6.60693, 8.60693), .Dim = c(
-        1L,
-        1L, 2L, 2L
-      ), class = "mcmcarray"), sigma = structure(11.2331, .Dim = c(
-        1L,
-        1L, 1L
-      ), class = "mcmcarray")
-    ), class = "mcmcr")
+    structure(
+      list(
+        alpha = structure(
+          c(7.17313, 8.17313),
+          .Dim = c(
+            1L,
+            1L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        beta = structure(
+          c(
+            -1.5662,
+            -0.5662,
+            -0.5662,
+            0.4338
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(5.60693, 7.60693, 6.60693, 8.60693),
+          .Dim = c(
+            1L,
+            1L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        sigma = structure(
+          11.2331,
+          .Dim = c(
+            1L,
+            1L,
+            1L
+          ),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -591,48 +1182,103 @@ test_that("mcmc_derive with alpha", {
   mcmcr <- subset(mcmcr::mcmcr_example, 1L, 1L)
 
   expect_equal(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       "gamma <- alpha + beta
    alpha <- alpha * 2",
-      primary = FALSE, silent = TRUE
+      primary = FALSE,
+      silent = TRUE
     ),
-    structure(list(gamma = structure(c(
-      5.60693, 7.60693, 6.60693,
-      8.60693
-    ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(
+            5.60693,
+            7.60693,
+            6.60693,
+            8.60693
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   expect_equal(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       "gamma <- alpha + beta
    alpha <- alpha * 2",
-      values = list(alpha = 3), primary = FALSE, silent = TRUE
+      values = list(alpha = 3),
+      primary = FALSE,
+      silent = TRUE
     ),
-    structure(list(gamma = structure(c(1.4338, 2.4338, 2.4338, 3.4338), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(1.4338, 2.4338, 2.4338, 3.4338),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   expect_equal(
-    mcmc_derive(mcmcr,
+    mcmc_derive(
+      mcmcr,
       "gamma <- alpha + beta
    alpha <- alpha * 2",
-      values = list(alpha = 3), primary = TRUE, silent = TRUE
+      values = list(alpha = 3),
+      primary = TRUE,
+      silent = TRUE
     ),
-    structure(list(
-      alpha = structure(c(7.17313, 8.17313), .Dim = c(
-        1L,
-        1L, 2L
-      ), class = "mcmcarray"), beta = structure(c(
-        -1.5662, -0.5662,
-        -0.5662, 0.4338
-      ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray"),
-      gamma = structure(c(1.4338, 2.4338, 2.4338, 3.4338), .Dim = c(
-        1L,
-        1L, 2L, 2L
-      ), class = "mcmcarray"), sigma = structure(11.2331, .Dim = c(
-        1L,
-        1L, 1L
-      ), class = "mcmcarray")
-    ), class = "mcmcr")
+    structure(
+      list(
+        alpha = structure(
+          c(7.17313, 8.17313),
+          .Dim = c(
+            1L,
+            1L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        beta = structure(
+          c(
+            -1.5662,
+            -0.5662,
+            -0.5662,
+            0.4338
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        ),
+        gamma = structure(
+          c(1.4338, 2.4338, 2.4338, 3.4338),
+          .Dim = c(
+            1L,
+            1L,
+            2L,
+            2L
+          ),
+          class = "mcmcarray"
+        ),
+        sigma = structure(
+          11.2331,
+          .Dim = c(
+            1L,
+            1L,
+            1L
+          ),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })
 
@@ -642,42 +1288,69 @@ test_that("mcmc_derive.nlist", {
   values <- list()
 
   expect_equal(
-    mcmc_derive(mcmcr, "gamma <- alpha + beta",
-      values = values,
-      silent = TRUE
-    ),
-    structure(list(gamma = structure(c(
-      5.60693, 7.60693, 6.60693,
-      8.60693
-    ), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    mcmc_derive(mcmcr, "gamma <- alpha + beta", values = values, silent = TRUE),
+    structure(
+      list(
+        gamma = structure(
+          c(
+            5.60693,
+            7.60693,
+            6.60693,
+            8.60693
+          ),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 
   values <- list(3)
 
-  expect_error(mcmc_derive(mcmcr, "gamma <- alpha + beta",
-    values = values,
-    silent = TRUE
-  ), "`values` must be named[.]", class = "chk_error")
+  expect_error(
+    mcmc_derive(mcmcr, "gamma <- alpha + beta", values = values, silent = TRUE),
+    "`values` must be named[.]",
+    class = "chk_error"
+  )
 
   values <- list(alpha = 3, alpha = 1)
 
-  expect_error(mcmc_derive(mcmcr, "gamma <- alpha + beta",
-    values = values,
-    silent = TRUE
-  ), "`names[(]values[)]` must be unique.", class = "chk_error")
+  expect_error(
+    mcmc_derive(mcmcr, "gamma <- alpha + beta", values = values, silent = TRUE),
+    "`names[(]values[)]` must be unique.",
+    class = "chk_error"
+  )
 
   values <- list(alpha = 3)
 
   expect_equal(
     mcmc_derive(mcmcr, "gamma <- alpha + beta", values = values, silent = TRUE),
-    structure(list(gamma = structure(c(1.4338, 2.4338, 2.4338, 3.4338), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(1.4338, 2.4338, 2.4338, 3.4338),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
-
 
   values <- nlist::nlist(alpha = 3)
 
   expect_equal(
     mcmc_derive(mcmcr, "gamma <- alpha + beta", values = values, silent = TRUE),
-    structure(list(gamma = structure(c(1.4338, 2.4338, 2.4338, 3.4338), .Dim = c(1L, 1L, 2L, 2L), class = "mcmcarray")), class = "mcmcr")
+    structure(
+      list(
+        gamma = structure(
+          c(1.4338, 2.4338, 2.4338, 3.4338),
+          .Dim = c(1L, 1L, 2L, 2L),
+          class = "mcmcarray"
+        )
+      ),
+      class = "mcmcr"
+    )
   )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)